### PR TITLE
fix: Option should be --no-renames

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -20,7 +20,7 @@ writer = CommentWriter.new(event, github_client, magic_text)
 # Assuming we're merging into main, then
 # HEAD^1 is `main`, and HEAD^2 is the branch we're merging.
 # HEAD^1..HEAD is therefore the change introduced by this PR.
-added_or_removed_files = `git diff --stat --name-only -z --diff-filter=AD --no-rename HEAD^1..HEAD`
+added_or_removed_files = `git diff --stat --name-only -z --diff-filter=AD --no-renames HEAD^1..HEAD`
 $CHILD_STATUS.success? or raise 'git diff failed'
 
 active = added_or_removed_files.split("\0").any? { |path| path.start_with?('kubernetes/manifests/') }


### PR DESCRIPTION
git 2.43.0: accepted --no-rename
git 2.43.2: refuses --no-rename

We didn't test 2.43.1